### PR TITLE
feat(app-router): Added a route guard. A bug persists where you need …

### DIFF
--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -8,6 +8,10 @@ const mapActionsToProps = dispatch => ({
   }
 })
 
+// TODO: Make it so logging in waits for the redux to get the values before finish onLogin(). This prevents
+// the double log in bug which is occuring because the redux doesn't get the values fast enough before the
+// relocation happens.
+
 class LoginForm extends Component {
   state = {
     email: "",

--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,3 +1,3 @@
 const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
 
-export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';
+export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) <= 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,16 +1,30 @@
 import React from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 import { Main, Login, OrderForm, ViewOrders } from '../components';
+import { connect } from 'react-redux';
+
+const mapStateToProps = (state) => ({
+    auth: state.auth,
+})
+
+const GuardedRoute = ({ component: Component, auth, ...rest }) => (
+    <Route {...rest} render={(props) => (
+        auth != null 
+            ? <Component {...props} />
+            : <Redirect to='/login' />
+    )} />
+)
 
 const AppRouter = (props) => {
+  console.log('props', props);
   return (
     <Router>
       <Route path="/" exact component={Main} />
-      <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+	  <Route path='/login' exact component={Login} />
+	  <GuardedRoute path='/order' exact component={OrderForm} auth={props.auth.token} />
+	  <GuardedRoute path='/view-orders' exact component={ViewOrders} auth={props.auth.token} />
     </Router>
   );
 }
 
-export default AppRouter;
+export default connect(mapStateToProps, null) (AppRouter);


### PR DESCRIPTION
…to login twice. See login-form component for logical steps to fix.

The route guard works, but there is an issue where login needs to happen twice to get to the order forms. The steps to fix this issue would be to make the login procedure wait until redux gets the auth info (email and token), and then redirect to /view-orders afterwards.